### PR TITLE
fix: remove unsupported routes config from wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,14 +4,6 @@ compatibility_date = "2024-12-20"
 # Pages configuration
 pages_build_output_dir = "public"
 
-# Production deployment
-[env.production]
-name = "kris-kryngle-coordinator"
-vars = { ENVIRONMENT = "production" }
-routes = [
-  { pattern = "kris-kryngle-coordinator.dilger.dev/*", zone_name = "dilger.dev" }
-]
-
 # Uncomment to use KV namespaces
 # [[kv_namespaces]]
 # binding = "MY_KV"


### PR DESCRIPTION
Fixes deployment failure caused by unsupported `routes` configuration in wrangler.toml.

Cloudflare Pages doesn't support the `routes` field - that's only for Workers. Custom domains should be configured via the Cloudflare dashboard instead.

Fixes #5

---
Generated with [Claude Code](https://claude.ai/code)