### PR TITLE
Add group name and shareable assignment links

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -37,6 +37,19 @@
 
         <!-- Main Card -->
         <div class="bg-white rounded-2xl shadow-xl p-6 md:p-8 mb-6">
+            <!-- Group Name Section -->
+            <div class="mb-8">
+                <label for="groupNameInput" class="block text-sm font-semibold text-gray-700 mb-2">
+                    Group Name
+                </label>
+                <input
+                    type="text"
+                    id="groupNameInput"
+                    placeholder="e.g., Office Party 2025"
+                    class="w-full px-4 py-2 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:outline-none transition-colors"
+                >
+            </div>
+
             <!-- Add Name Section -->
             <div class="mb-8">
                 <label for="nameInput" class="block text-sm font-semibold text-gray-700 mb-2">
@@ -94,7 +107,7 @@
                     🎁 Secret Santa Assignments
                 </h2>
                 <p class="text-gray-600">
-                    Click on a name to reveal who they're buying for!
+                    Share these links with each participant - they'll see only their assignment!
                 </p>
             </div>
             <div id="resultsList" class="space-y-3">
@@ -228,37 +241,72 @@
             displayResults(allocations);
         }
 
-        // Display the results with reveal functionality
+        // Display the results with link generation
         function displayResults(allocations) {
             const resultsCard = document.getElementById('resultsCard');
             const resultsList = document.getElementById('resultsList');
+            const groupName = document.getElementById('groupNameInput').value.trim() || 'Secret Santa';
 
-            resultsList.innerHTML = Object.entries(allocations).map(([giver, receiver]) => `
-                <div class="result-item">
-                    <button
-                        onclick="toggleReveal(this)"
-                        class="w-full text-left p-4 bg-gradient-to-r from-red-100 to-green-100 hover:from-red-200 hover:to-green-200 rounded-lg transition-all border-2 border-gray-200"
-                    >
-                        <div class="flex items-center justify-between">
-                            <span class="font-bold text-gray-800">${escapeHtml(giver)}</span>
-                            <span class="text-sm text-gray-600">Click to reveal →</span>
-                        </div>
-                        <div class="receiver hidden mt-2 pt-2 border-t border-gray-300">
-                            <span class="text-gray-700">is buying for...</span>
-                            <span class="font-bold text-green-700 ml-2">🎁 ${escapeHtml(receiver)}</span>
-                        </div>
-                    </button>
-                </div>
-            `).join('');
+            // Clear previous results
+            resultsList.innerHTML = '';
+
+            // Create elements for each allocation
+            Object.entries(allocations).forEach(([giver, receiver]) => {
+                const link = generateAssignmentLink(groupName, giver, receiver);
+
+                const resultItem = document.createElement('div');
+                resultItem.className = 'result-item';
+
+                const container = document.createElement('div');
+                container.className = 'flex items-center gap-2 p-4 bg-gradient-to-r from-red-100 to-green-100 rounded-lg border-2 border-gray-200';
+
+                const nameSpan = document.createElement('span');
+                nameSpan.className = 'flex-1 font-bold text-gray-800';
+                nameSpan.textContent = giver;
+
+                const button = document.createElement('button');
+                button.className = 'px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white font-semibold rounded transition-colors';
+                button.textContent = '📋 Click to copy link';
+                button.onclick = () => copyLink(link, button);
+
+                container.appendChild(nameSpan);
+                container.appendChild(button);
+                resultItem.appendChild(container);
+                resultsList.appendChild(resultItem);
+            });
 
             resultsCard.classList.remove('hidden');
             resultsCard.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
         }
 
-        // Toggle reveal of an assignment
-        function toggleReveal(button) {
-            const receiver = button.querySelector('.receiver');
-            receiver.classList.toggle('hidden');
+        // Generate a shareable link for an assignment
+        function generateAssignmentLink(groupName, name, assignment) {
+            // Base64 encode the assignment to keep it hidden in the URL
+            const encodedAssignment = btoa(assignment);
+
+            // Use hash parameters for privacy (not logged by servers)
+            return `${location.origin}/view.html#group=${encodeURIComponent(groupName)}&name=${encodeURIComponent(name)}&assignment=${encodeURIComponent(encodedAssignment)}`;
+        }
+
+        // Copy link to clipboard
+        async function copyLink(link, button) {
+            try {
+                await navigator.clipboard.writeText(link);
+
+                // Visual feedback - change button text temporarily
+                const originalText = button.innerHTML;
+                button.innerHTML = '✅ Copied!';
+                button.classList.add('bg-green-500', 'hover:bg-green-600');
+                button.classList.remove('bg-blue-500', 'hover:bg-blue-600');
+
+                setTimeout(() => {
+                    button.innerHTML = originalText;
+                    button.classList.remove('bg-green-500', 'hover:bg-green-600');
+                    button.classList.add('bg-blue-500', 'hover:bg-blue-600');
+                }, 2000);
+            } catch (err) {
+                alert('Oops! Failed to copy the link. Please try again! 🎅');
+            }
         }
 
         // Reset the app to start over

--- a/public/view.html
+++ b/public/view.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Your Kris Kringle Assignment 🎁</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        @keyframes fadeIn {
+            from { opacity: 0; transform: translateY(20px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+        .fade-in {
+            animation: fadeIn 0.5s ease-out;
+        }
+        @keyframes sparkle {
+            0%, 100% { transform: scale(1) rotate(0deg); }
+            50% { transform: scale(1.1) rotate(5deg); }
+        }
+        .sparkle {
+            animation: sparkle 2s ease-in-out infinite;
+        }
+    </style>
+</head>
+<body class="bg-gradient-to-br from-red-50 via-green-50 to-blue-50 min-h-screen flex items-center justify-center py-8 px-4">
+    <div class="max-w-md w-full">
+        <!-- Loading State -->
+        <div id="loadingState" class="text-center">
+            <div class="text-6xl mb-4 sparkle">🎅</div>
+            <p class="text-gray-600">Loading your assignment...</p>
+        </div>
+
+        <!-- Error State -->
+        <div id="errorState" class="hidden text-center">
+            <div class="bg-white rounded-2xl shadow-xl p-8">
+                <div class="text-6xl mb-4">😅</div>
+                <h1 class="text-2xl font-bold text-gray-800 mb-4">
+                    Oops! Something went wrong
+                </h1>
+                <p class="text-gray-600 mb-6" id="errorMessage">
+                    This link doesn't seem to be valid. Please check with your organizer!
+                </p>
+                <a
+                    href="/"
+                    class="inline-block px-6 py-3 bg-blue-500 hover:bg-blue-600 text-white font-semibold rounded-lg transition-colors"
+                >
+                    Go to Home
+                </a>
+            </div>
+        </div>
+
+        <!-- Assignment Display -->
+        <div id="assignmentDisplay" class="hidden fade-in">
+            <div class="bg-white rounded-2xl shadow-xl p-8 text-center">
+                <div class="text-6xl mb-6 sparkle">🎁</div>
+
+                <div class="mb-6">
+                    <h2 class="text-sm font-semibold text-gray-500 mb-2">
+                        <span id="groupName"></span>
+                    </h2>
+                    <h1 class="text-3xl font-bold text-gray-800 mb-2">
+                        Hi, <span id="participantName" class="text-green-600"></span>!
+                    </h1>
+                </div>
+
+                <div class="bg-gradient-to-r from-red-100 to-green-100 rounded-xl p-6 mb-6">
+                    <p class="text-gray-700 mb-3">You're buying a gift for...</p>
+                    <p class="text-4xl font-bold text-green-700" id="assignedPerson">
+                        <!-- Assignment will be shown here -->
+                    </p>
+                </div>
+
+                <div class="text-sm text-gray-500 space-y-2">
+                    <p>🤫 Keep it secret, keep it fun!</p>
+                    <p>✨ Happy gift hunting!</p>
+                </div>
+            </div>
+
+            <div class="text-center mt-6">
+                <a
+                    href="/"
+                    class="text-gray-500 hover:text-gray-700 text-sm transition-colors"
+                >
+                    ← Back to coordinator
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        // Parse the hash parameters
+        function parseHashParams() {
+            const hash = window.location.hash.substring(1); // Remove the '#'
+            const params = new URLSearchParams(hash);
+
+            return {
+                group: params.get('group'),
+                name: params.get('name'),
+                assignment: params.get('assignment')
+            };
+        }
+
+        // Decode the base64 encoded assignment
+        function decodeAssignment(encoded) {
+            try {
+                return atob(encoded);
+            } catch (e) {
+                throw new Error('Invalid assignment encoding');
+            }
+        }
+
+        // Escape HTML to prevent XSS
+        function escapeHtml(text) {
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+
+        // Display the assignment
+        function displayAssignment() {
+            const loadingState = document.getElementById('loadingState');
+            const errorState = document.getElementById('errorState');
+            const assignmentDisplay = document.getElementById('assignmentDisplay');
+            const errorMessage = document.getElementById('errorMessage');
+
+            try {
+                const params = parseHashParams();
+
+                // Validate that we have all required parameters
+                if (!params.group || !params.name || !params.assignment) {
+                    throw new Error('Missing required parameters');
+                }
+
+                // Decode the assignment
+                const assignedPerson = decodeAssignment(params.assignment);
+
+                // Update the display with the assignment info
+                document.getElementById('groupName').textContent = params.group;
+                document.getElementById('participantName').textContent = params.name;
+                document.getElementById('assignedPerson').textContent = assignedPerson;
+
+                // Update the page title
+                document.title = `${params.name}'s Assignment - ${params.group}`;
+
+                // Show the assignment display
+                loadingState.classList.add('hidden');
+                assignmentDisplay.classList.remove('hidden');
+
+            } catch (error) {
+                console.error('Error displaying assignment:', error);
+
+                // Show error state
+                loadingState.classList.add('hidden');
+                errorState.classList.remove('hidden');
+
+                if (error.message === 'Missing required parameters') {
+                    errorMessage.textContent = 'This link is incomplete. Please check with your organizer for the correct link!';
+                } else if (error.message === 'Invalid assignment encoding') {
+                    errorMessage.textContent = 'This link appears to be corrupted. Please request a new one from your organizer!';
+                } else {
+                    errorMessage.textContent = 'Something unexpected happened. Please check with your organizer!';
+                }
+            }
+        }
+
+        // Initialize when the page loads
+        displayAssignment();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Implements #7

Adds two key features to prevent the host from seeing assignments:

- **Group name field**: Allows hosts to set a context name shown on assignment pages
- **Shareable links**: Instead of revealing assignments, generates unique links for each participant
- **New view page**: Displays individual assignments with base64-decoded names
- **Privacy-focused**: Uses hash parameters to keep names out of server logs

The host never sees the actual assignments, reducing awkwardness!

🎁 Generated with [Claude Code](https://claude.ai/code)